### PR TITLE
DUPLO-43460: honor --tenant region for admin/duplo-ops AWS JIT console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- `duplo-jit aws --admin`/`--duplo-ops` now honor `--tenant`: the returned `Region` and console URL open in the selected tenant's region instead of the master account's default region (DUPLO-43460).
+
 ## 2026-02-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Fixed
 - `duplo-jit aws --admin`/`--duplo-ops` now honor `--tenant`: the returned `Region` and console URL open in the selected tenant's region instead of the master account's default region (DUPLO-43460).
 
+### Changed
+- `duplo-jit aws --admin`/`--duplo-ops` with `--tenant` resolves the tenant before reading the credential cache (the tenant name is part of the cache key), so a cache hit can still prompt for Duplo login when the cached Duplo token has expired, as the `--tenant`-only path already does. A tenant with no configured region, or a console URL whose region could not be rewritten, is reported on stderr.
+- `make test` now runs `go test ./...`.
+
 ## 2026-02-24
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ install: all
 	sudo install -o root -m 755 duplo-jit /usr/local/bin/duplo-jit
 
 test: all
+	go test ./...
 
 all: duplo-aws-credential-process duplo-jit
 

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -227,17 +227,14 @@ func getAdminAwsCreds(host, apiHost, token string, interactive bool, port int, r
 	cacheKey = strings.Join([]string{cacheKey, role}, ",")
 
 	var client *duplocloud.Client
-	var tenantRegion string
+	var tenantID, tenantName string
 
-	// If a tenant is selected, resolve its region and scope the cache to it.
+	// If a tenant is selected, scope the cache to it. Resolving the tenant name needs
+	// a client, so this runs ahead of the cache read, as the plain tenant path does.
 	if tenantIDorName != "" {
 		client, _ = internal.MustDuploClient(host, apiHost, token, interactive, true, port)
-		tenantID, tenantName := getTenantIDAndName(tenantIDorName, client)
+		tenantID, tenantName = getTenantIDAndName(tenantIDorName, client)
 		cacheKey = strings.Join([]string{cacheKey, "tenant", tenantName}, ",")
-
-		features, err := client.GetTenantFeatures(tenantID)
-		internal.DieIf(err, "failed to get tenant region")
-		tenantRegion = features.Region
 	}
 
 	// Try to find credentials from the cache.
@@ -252,8 +249,17 @@ func getAdminAwsCreds(host, apiHost, token string, interactive bool, port int, r
 		internal.DieIf(err, "failed to get credentials")
 		creds = internal.ConvertAwsCreds(result)
 
-		// Open the console in the tenant's region rather than the master default.
-		internal.ApplyTenantRegion(creds, tenantRegion)
+		// Open the console in the tenant's region rather than the master default. The
+		// region is baked into the cached credentials, so it is only looked up on a miss.
+		if tenantID != "" {
+			features, err := client.GetTenantFeatures(tenantID)
+			internal.DieIf(err, "failed to get tenant region")
+			if features.Region == "" {
+				fmt.Fprintf(os.Stderr, "warning: tenant %q has no region configured; using the master account default region\n", tenantName)
+			} else if !internal.ApplyTenantRegion(creds, features.Region) {
+				fmt.Fprintf(os.Stderr, "warning: could not rewrite the console URL for region %s; the console may open in a different region\n", features.Region)
+			}
+		}
 	}
 
 	return creds, cacheKey

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -125,35 +125,11 @@ func main() {
 		var creds *internal.AwsConfigOutput
 		if *admin {
 
-			// Build the cache key
-			cacheKey = strings.Join([]string{cacheKey, "admin"}, ",")
-
-			// Try to find credentials from the cache.
-			creds = internal.CacheGetAwsConfigOutput(cacheKey)
-
-			// Otherwise, get the credentials from Duplo.
-			if creds == nil {
-				client, _ := internal.MustDuploClient(*host, *apiHost, *token, *interactive, true, *port)
-				result, err := client.AdminGetJitAwsCredentials()
-				internal.DieIf(err, "failed to get credentials")
-				creds = internal.ConvertAwsCreds(result)
-			}
+			creds, cacheKey = getAdminAwsCreds(*host, *apiHost, *token, *interactive, *port, "admin", cacheKey, *tenantID)
 
 		} else if *duploOps {
 
-			// Build the cache key
-			cacheKey = strings.Join([]string{cacheKey, "duplo-ops"}, ",")
-
-			// Try to find credentials from the cache.
-			creds = internal.CacheGetAwsConfigOutput(cacheKey)
-
-			// Otherwise, get the credentials from Duplo.
-			if creds == nil {
-				client, _ := internal.MustDuploClient(*host, *apiHost, *token, *interactive, true, *port)
-				result, err := client.AdminAwsGetJitAccess("duplo-ops")
-				internal.DieIf(err, "failed to get credentials")
-				creds = internal.ConvertAwsCreds(result)
-			}
+			creds, cacheKey = getAdminAwsCreds(*host, *apiHost, *token, *interactive, *port, "duplo-ops", cacheKey, *tenantID)
 
 		} else if tenantID == nil || *tenantID == "" {
 
@@ -239,6 +215,48 @@ func main() {
 		internal.OutputK8sCreds(creds, cacheKey)
 
 	}
+}
+
+// getAdminAwsCreds retrieves JIT AWS credentials for an admin role ("admin" or
+// "duplo-ops"). When a tenant is supplied, the credentials' region and console URL
+// are overridden to point at the tenant's region (the admin JIT API otherwise
+// returns the master account's default region), and the tenant name is folded into
+// the cache key so credentials are cached per-tenant. It returns the credentials
+// and the (possibly extended) cache key.
+func getAdminAwsCreds(host, apiHost, token string, interactive bool, port int, role, cacheKey, tenantIDorName string) (*internal.AwsConfigOutput, string) {
+	cacheKey = strings.Join([]string{cacheKey, role}, ",")
+
+	var client *duplocloud.Client
+	var tenantRegion string
+
+	// If a tenant is selected, resolve its region and scope the cache to it.
+	if tenantIDorName != "" {
+		client, _ = internal.MustDuploClient(host, apiHost, token, interactive, true, port)
+		tenantID, tenantName := getTenantIDAndName(tenantIDorName, client)
+		cacheKey = strings.Join([]string{cacheKey, "tenant", tenantName}, ",")
+
+		features, err := client.GetTenantFeatures(tenantID)
+		internal.DieIf(err, "failed to get tenant region")
+		tenantRegion = features.Region
+	}
+
+	// Try to find credentials from the cache.
+	creds := internal.CacheGetAwsConfigOutput(cacheKey)
+
+	// Otherwise, get the credentials from Duplo.
+	if creds == nil {
+		if client == nil {
+			client, _ = internal.MustDuploClient(host, apiHost, token, interactive, true, port)
+		}
+		result, err := client.AdminAwsGetJitAccess(role)
+		internal.DieIf(err, "failed to get credentials")
+		creds = internal.ConvertAwsCreds(result)
+
+		// Open the console in the tenant's region rather than the master default.
+		internal.ApplyTenantRegion(creds, tenantRegion)
+	}
+
+	return creds, cacheKey
 }
 
 func getTenantIDAndName(tenantIDorName string, client *duplocloud.Client) (string, string) {

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -125,11 +125,11 @@ func main() {
 		var creds *internal.AwsConfigOutput
 		if *admin {
 
-			creds, cacheKey = getAdminAwsCreds(*host, *apiHost, *token, *interactive, *port, "admin", cacheKey, *tenantID)
+			creds, cacheKey = getAdminAwsCreds(*host, *apiHost, *token, *interactive, *port, "admin", *tenantID)
 
 		} else if *duploOps {
 
-			creds, cacheKey = getAdminAwsCreds(*host, *apiHost, *token, *interactive, *port, "duplo-ops", cacheKey, *tenantID)
+			creds, cacheKey = getAdminAwsCreds(*host, *apiHost, *token, *interactive, *port, "duplo-ops", *tenantID)
 
 		} else if tenantID == nil || *tenantID == "" {
 
@@ -222,9 +222,9 @@ func main() {
 // are overridden to point at the tenant's region (the admin JIT API otherwise
 // returns the master account's default region), and the tenant name is folded into
 // the cache key so credentials are cached per-tenant. It returns the credentials
-// and the (possibly extended) cache key.
-func getAdminAwsCreds(host, apiHost, token string, interactive bool, port int, role, cacheKey, tenantIDorName string) (*internal.AwsConfigOutput, string) {
-	cacheKey = strings.Join([]string{cacheKey, role}, ",")
+// and the cache key they live under.
+func getAdminAwsCreds(host, apiHost, token string, interactive bool, port int, role, tenantIDorName string) (*internal.AwsConfigOutput, string) {
+	cacheKey := strings.Join([]string{internal.GetHostCacheKey(host), role}, ",")
 
 	var client *duplocloud.Client
 	var tenantID, tenantName string

--- a/internal/aws.go
+++ b/internal/aws.go
@@ -46,46 +46,67 @@ func ConvertAwsCreds(creds *duplocloud.AwsJitCredentials) *AwsConfigOutput {
 }
 
 // OverrideConsoleRegion returns the AWS federation console URL with the region of
-// its Destination target replaced. Admin / duplo-ops JIT URLs open in the master
-// account's default region; when a tenant is selected we want the console to open
-// in that tenant's region instead. The SigninToken is left untouched.
-func OverrideConsoleRegion(consoleUrl, region string) string {
+// its Destination target replaced, and whether a rewrite happened. Admin / duplo-ops
+// JIT URLs open in the master account's default region; when a tenant is selected we
+// want the console to open in that tenant's region instead.
+//
+// The URL comes back unchanged (false) when it is empty, cannot be fully parsed, has
+// no Destination, or the Destination carries no region query param (for example a
+// region encoded in the host). Only the Destination query is rewritten; a region
+// inside its fragment is carried through as-is. The SigninToken value is preserved
+// (re-encoded equivalently).
+func OverrideConsoleRegion(consoleUrl, region string) (string, bool) {
 	if consoleUrl == "" || region == "" {
-		return consoleUrl
+		return consoleUrl, false
 	}
 	u, err := url.Parse(consoleUrl)
 	if err != nil {
-		return consoleUrl
+		return consoleUrl, false
 	}
-	q := u.Query()
+	// u.Query() silently drops malformed pairs, and re-encoding would then lose them
+	// (SigninToken included), so never re-serialize a query that did not fully parse.
+	q, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return consoleUrl, false
+	}
 	dest := q.Get("Destination")
 	if dest == "" {
-		return consoleUrl
+		return consoleUrl, false
 	}
 	d, err := url.Parse(dest)
 	if err != nil {
-		return consoleUrl
+		return consoleUrl, false
 	}
-	dq := d.Query()
+	dq, err := url.ParseQuery(d.RawQuery)
+	if err != nil {
+		return consoleUrl, false
+	}
 	if dq.Get("region") == "" {
-		return consoleUrl
+		return consoleUrl, false
 	}
 	dq.Set("region", region)
 	d.RawQuery = dq.Encode()
 	q.Set("Destination", d.String())
 	u.RawQuery = q.Encode()
-	return u.String()
+	return u.String(), true
 }
 
 // ApplyTenantRegion overrides the region reported by admin / duplo-ops JIT
 // credentials so that both the Region field and the console URL point at the
-// selected tenant's region.
-func ApplyTenantRegion(creds *AwsConfigOutput, region string) {
+// selected tenant's region. It returns false when nothing was applied, or when the
+// credentials carry a console URL that could not be rewritten and so no longer
+// agrees with Region.
+func ApplyTenantRegion(creds *AwsConfigOutput, region string) bool {
 	if creds == nil || region == "" {
-		return
+		return false
 	}
-	creds.ConsoleUrl = OverrideConsoleRegion(creds.ConsoleUrl, region)
 	creds.Region = region
+	if creds.ConsoleUrl == "" {
+		return true
+	}
+	var ok bool
+	creds.ConsoleUrl, ok = OverrideConsoleRegion(creds.ConsoleUrl, region)
+	return ok
 }
 
 func OutputAwsCreds(creds *AwsConfigOutput, cacheKey string) {

--- a/internal/aws.go
+++ b/internal/aws.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -42,6 +43,49 @@ func ConvertAwsCreds(creds *duplocloud.AwsJitCredentials) *AwsConfigOutput {
 		SessionToken:    creds.SessionToken,
 		Expiration:      expiration.Format(time.RFC3339),
 	}
+}
+
+// OverrideConsoleRegion returns the AWS federation console URL with the region of
+// its Destination target replaced. Admin / duplo-ops JIT URLs open in the master
+// account's default region; when a tenant is selected we want the console to open
+// in that tenant's region instead. The SigninToken is left untouched.
+func OverrideConsoleRegion(consoleUrl, region string) string {
+	if consoleUrl == "" || region == "" {
+		return consoleUrl
+	}
+	u, err := url.Parse(consoleUrl)
+	if err != nil {
+		return consoleUrl
+	}
+	q := u.Query()
+	dest := q.Get("Destination")
+	if dest == "" {
+		return consoleUrl
+	}
+	d, err := url.Parse(dest)
+	if err != nil {
+		return consoleUrl
+	}
+	dq := d.Query()
+	if dq.Get("region") == "" {
+		return consoleUrl
+	}
+	dq.Set("region", region)
+	d.RawQuery = dq.Encode()
+	q.Set("Destination", d.String())
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// ApplyTenantRegion overrides the region reported by admin / duplo-ops JIT
+// credentials so that both the Region field and the console URL point at the
+// selected tenant's region.
+func ApplyTenantRegion(creds *AwsConfigOutput, region string) {
+	if creds == nil || region == "" {
+		return
+	}
+	creds.ConsoleUrl = OverrideConsoleRegion(creds.ConsoleUrl, region)
+	creds.Region = region
 }
 
 func OutputAwsCreds(creds *AwsConfigOutput, cacheKey string) {

--- a/internal/aws_test.go
+++ b/internal/aws_test.go
@@ -24,9 +24,55 @@ func destinationRegion(t *testing.T, consoleUrl string) string {
 	return d.Query().Get("region")
 }
 
+// signinToken returns the SigninToken query param of a federation console URL.
+func signinToken(t *testing.T, consoleUrl string) string {
+	t.Helper()
+	u, err := url.Parse(consoleUrl)
+	if err != nil {
+		t.Fatalf("parse console url: %s", err)
+	}
+	return u.Query().Get("SigninToken")
+}
+
+// assertUnchanged checks that OverrideConsoleRegion declined to rewrite and returned its input.
+func assertUnchanged(t *testing.T, in, got string, ok bool) {
+	t.Helper()
+	if ok {
+		t.Fatalf("expected ok=false")
+	}
+	if got != in {
+		t.Fatalf("expected url unchanged, got %q", got)
+	}
+}
+
+// assertRewritten checks that OverrideConsoleRegion rewrote the Destination region and kept the SigninToken.
+func assertRewritten(t *testing.T, got string, ok bool, wantRegion, wantToken string) {
+	t.Helper()
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if r := destinationRegion(t, got); r != wantRegion {
+		t.Fatalf("destination region = %q, want %q", r, wantRegion)
+	}
+	if tok := signinToken(t, got); tok != wantToken {
+		t.Fatalf("SigninToken = %q, want %q", tok, wantToken)
+	}
+}
+
+// assertCreds checks the Region and ConsoleUrl left on the credentials by ApplyTenantRegion.
+func assertCreds(t *testing.T, creds *AwsConfigOutput, wantRegion, wantUrl string) {
+	t.Helper()
+	if creds.Region != wantRegion || creds.ConsoleUrl != wantUrl {
+		t.Fatalf("got region=%q url=%q, want region=%q url=%q", creds.Region, creds.ConsoleUrl, wantRegion, wantUrl)
+	}
+}
+
 // A realistic federation URL with a URL-encoded Destination (lowercase %3d,
 // matching what the Duplo API returns).
 const realisticConsoleUrl = "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc-DEF_123&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2"
+
+// A Destination with the region encoded in the host rather than the query, which the rewrite cannot handle.
+const hostRegionConsoleUrl = "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc&Destination=https%3a%2f%2fus-west-2.console.aws.amazon.com%2fconsole%2fhome"
 
 func TestOverrideConsoleRegion(t *testing.T) {
 	tests := []struct {
@@ -68,7 +114,7 @@ func TestOverrideConsoleRegion(t *testing.T) {
 		},
 		{
 			name:       "region in destination host is not rewritten",
-			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc&Destination=https%3a%2f%2fus-west-2.console.aws.amazon.com%2fconsole%2fhome",
+			consoleUrl: hostRegionConsoleUrl,
 			region:     "us-east-2",
 		},
 		{
@@ -88,31 +134,10 @@ func TestOverrideConsoleRegion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := OverrideConsoleRegion(tt.consoleUrl, tt.region)
-
 			if tt.wantRegion == "" {
-				if ok {
-					t.Fatalf("expected ok=false")
-				}
-				if got != tt.consoleUrl {
-					t.Fatalf("expected url unchanged, got %q", got)
-				}
-				return
-			}
-
-			if !ok {
-				t.Fatalf("expected ok=true")
-			}
-			if r := destinationRegion(t, got); r != tt.wantRegion {
-				t.Fatalf("destination region = %q, want %q", r, tt.wantRegion)
-			}
-
-			// The SigninToken must survive the rewrite intact.
-			u, err := url.Parse(got)
-			if err != nil {
-				t.Fatalf("parse result: %s", err)
-			}
-			if tok := u.Query().Get("SigninToken"); tok != "abc-DEF_123" {
-				t.Fatalf("SigninToken = %q, want abc-DEF_123", tok)
+				assertUnchanged(t, tt.consoleUrl, got, ok)
+			} else {
+				assertRewritten(t, got, ok, tt.wantRegion, "abc-DEF_123")
 			}
 		})
 	}
@@ -137,20 +162,15 @@ func TestApplyTenantRegion(t *testing.T) {
 		if !ApplyTenantRegion(creds, "us-east-2") {
 			t.Fatalf("expected true")
 		}
-		if creds.Region != "us-east-2" || creds.ConsoleUrl != "" {
-			t.Fatalf("got region=%q url=%q", creds.Region, creds.ConsoleUrl)
-		}
+		assertCreds(t, creds, "us-east-2", "")
 	})
 
 	t.Run("console url that cannot be rewritten reports false", func(t *testing.T) {
-		hostRegion := "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc&Destination=https%3a%2f%2fus-west-2.console.aws.amazon.com%2fconsole%2fhome"
-		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: hostRegion}
+		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: hostRegionConsoleUrl}
 		if ApplyTenantRegion(creds, "us-east-2") {
 			t.Fatalf("expected false")
 		}
-		if creds.Region != "us-east-2" || creds.ConsoleUrl != hostRegion {
-			t.Fatalf("got region=%q url=%q", creds.Region, creds.ConsoleUrl)
-		}
+		assertCreds(t, creds, "us-east-2", hostRegionConsoleUrl)
 	})
 
 	t.Run("empty region is a no-op", func(t *testing.T) {
@@ -158,9 +178,7 @@ func TestApplyTenantRegion(t *testing.T) {
 		if ApplyTenantRegion(creds, "") {
 			t.Fatalf("expected false")
 		}
-		if creds.Region != "us-west-2" || creds.ConsoleUrl != realisticConsoleUrl {
-			t.Fatalf("expected creds unchanged, got region=%q", creds.Region)
-		}
+		assertCreds(t, creds, "us-west-2", realisticConsoleUrl)
 	})
 
 	t.Run("nil creds does not panic", func(t *testing.T) {

--- a/internal/aws_test.go
+++ b/internal/aws_test.go
@@ -1,0 +1,125 @@
+package internal
+
+import (
+	"net/url"
+	"testing"
+)
+
+// destinationRegion parses the federation console URL and returns the region
+// query param of its Destination target.
+func destinationRegion(t *testing.T, consoleUrl string) string {
+	t.Helper()
+	u, err := url.Parse(consoleUrl)
+	if err != nil {
+		t.Fatalf("parse console url: %s", err)
+	}
+	dest := u.Query().Get("Destination")
+	if dest == "" {
+		return ""
+	}
+	d, err := url.Parse(dest)
+	if err != nil {
+		t.Fatalf("parse destination: %s", err)
+	}
+	return d.Query().Get("region")
+}
+
+func TestOverrideConsoleRegion(t *testing.T) {
+	// A realistic federation URL with a URL-encoded Destination (lowercase %3d,
+	// matching what the Duplo API returns).
+	realistic := "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc-DEF_123&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2"
+
+	tests := []struct {
+		name       string
+		consoleUrl string
+		region     string
+		wantRegion string // expected Destination region; "" means URL should be unchanged
+		unchanged  bool
+	}{
+		{
+			name:       "overrides region in destination",
+			consoleUrl: realistic,
+			region:     "us-east-2",
+			wantRegion: "us-east-2",
+		},
+		{
+			name:       "empty region leaves url unchanged",
+			consoleUrl: realistic,
+			region:     "",
+			unchanged:  true,
+		},
+		{
+			name:       "empty url returns empty",
+			consoleUrl: "",
+			region:     "us-east-2",
+			unchanged:  true,
+		},
+		{
+			name:       "no destination param leaves url unchanged",
+			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc",
+			region:     "us-east-2",
+			unchanged:  true,
+		},
+		{
+			name:       "destination without region param leaves url unchanged",
+			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome",
+			region:     "us-east-2",
+			unchanged:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OverrideConsoleRegion(tt.consoleUrl, tt.region)
+
+			if tt.unchanged {
+				if got != tt.consoleUrl {
+					t.Fatalf("expected url unchanged, got %q", got)
+				}
+				return
+			}
+
+			if r := destinationRegion(t, got); r != tt.wantRegion {
+				t.Fatalf("destination region = %q, want %q", r, tt.wantRegion)
+			}
+
+			// The SigninToken must survive the rewrite intact.
+			u, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("parse result: %s", err)
+			}
+			if tok := u.Query().Get("SigninToken"); tok != "abc-DEF_123" {
+				t.Fatalf("SigninToken = %q, want abc-DEF_123", tok)
+			}
+		})
+	}
+}
+
+func TestApplyTenantRegion(t *testing.T) {
+	consoleUrl := "https://signin.aws.amazon.com/federation?Action=login&SigninToken=tok&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2"
+
+	t.Run("overrides region and console url", func(t *testing.T) {
+		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: consoleUrl}
+		ApplyTenantRegion(creds, "us-east-2")
+
+		if creds.Region != "us-east-2" {
+			t.Fatalf("Region = %q, want us-east-2", creds.Region)
+		}
+		if r := destinationRegion(t, creds.ConsoleUrl); r != "us-east-2" {
+			t.Fatalf("console destination region = %q, want us-east-2", r)
+		}
+	})
+
+	t.Run("empty region is a no-op", func(t *testing.T) {
+		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: consoleUrl}
+		ApplyTenantRegion(creds, "")
+
+		if creds.Region != "us-west-2" || creds.ConsoleUrl != consoleUrl {
+			t.Fatalf("expected creds unchanged, got region=%q", creds.Region)
+		}
+	})
+
+	t.Run("nil creds does not panic", func(t *testing.T) {
+		ApplyTenantRegion(nil, "us-east-2")
+	})
+}

--- a/internal/aws_test.go
+++ b/internal/aws_test.go
@@ -24,61 +24,84 @@ func destinationRegion(t *testing.T, consoleUrl string) string {
 	return d.Query().Get("region")
 }
 
-func TestOverrideConsoleRegion(t *testing.T) {
-	// A realistic federation URL with a URL-encoded Destination (lowercase %3d,
-	// matching what the Duplo API returns).
-	realistic := "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc-DEF_123&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2"
+// A realistic federation URL with a URL-encoded Destination (lowercase %3d,
+// matching what the Duplo API returns).
+const realisticConsoleUrl = "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc-DEF_123&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2"
 
+func TestOverrideConsoleRegion(t *testing.T) {
 	tests := []struct {
 		name       string
 		consoleUrl string
 		region     string
-		wantRegion string // expected Destination region; "" means URL should be unchanged
-		unchanged  bool
+		wantRegion string // expected Destination region; "" means the URL must come back unchanged
 	}{
 		{
 			name:       "overrides region in destination",
-			consoleUrl: realistic,
+			consoleUrl: realisticConsoleUrl,
 			region:     "us-east-2",
 			wantRegion: "us-east-2",
 		},
 		{
 			name:       "empty region leaves url unchanged",
-			consoleUrl: realistic,
+			consoleUrl: realisticConsoleUrl,
 			region:     "",
-			unchanged:  true,
 		},
 		{
 			name:       "empty url returns empty",
 			consoleUrl: "",
 			region:     "us-east-2",
-			unchanged:  true,
+		},
+		{
+			name:       "unparseable url is left unchanged",
+			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login\x7f",
+			region:     "us-east-2",
 		},
 		{
 			name:       "no destination param leaves url unchanged",
 			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc",
 			region:     "us-east-2",
-			unchanged:  true,
 		},
 		{
 			name:       "destination without region param leaves url unchanged",
 			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome",
 			region:     "us-east-2",
-			unchanged:  true,
+		},
+		{
+			name:       "region in destination host is not rewritten",
+			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc&Destination=https%3a%2f%2fus-west-2.console.aws.amazon.com%2fconsole%2fhome",
+			region:     "us-east-2",
+		},
+		{
+			// url.Parse accepts these, but the query does not fully parse; re-encoding
+			// would drop the SigninToken, so the input must come back untouched.
+			name:       "malformed escape in query leaves url unchanged",
+			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&SigninToken=ab%zz&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2",
+			region:     "us-east-2",
+		},
+		{
+			name:       "semicolon in query leaves url unchanged",
+			consoleUrl: "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc;def&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2",
+			region:     "us-east-2",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := OverrideConsoleRegion(tt.consoleUrl, tt.region)
+			got, ok := OverrideConsoleRegion(tt.consoleUrl, tt.region)
 
-			if tt.unchanged {
+			if tt.wantRegion == "" {
+				if ok {
+					t.Fatalf("expected ok=false")
+				}
 				if got != tt.consoleUrl {
 					t.Fatalf("expected url unchanged, got %q", got)
 				}
 				return
 			}
 
+			if !ok {
+				t.Fatalf("expected ok=true")
+			}
 			if r := destinationRegion(t, got); r != tt.wantRegion {
 				t.Fatalf("destination region = %q, want %q", r, tt.wantRegion)
 			}
@@ -96,12 +119,11 @@ func TestOverrideConsoleRegion(t *testing.T) {
 }
 
 func TestApplyTenantRegion(t *testing.T) {
-	consoleUrl := "https://signin.aws.amazon.com/federation?Action=login&SigninToken=tok&Destination=https%3a%2f%2fconsole.aws.amazon.com%2fconsole%2fhome%3fregion%3dus-west-2"
-
 	t.Run("overrides region and console url", func(t *testing.T) {
-		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: consoleUrl}
-		ApplyTenantRegion(creds, "us-east-2")
-
+		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: realisticConsoleUrl}
+		if !ApplyTenantRegion(creds, "us-east-2") {
+			t.Fatalf("expected true")
+		}
 		if creds.Region != "us-east-2" {
 			t.Fatalf("Region = %q, want us-east-2", creds.Region)
 		}
@@ -110,16 +132,40 @@ func TestApplyTenantRegion(t *testing.T) {
 		}
 	})
 
-	t.Run("empty region is a no-op", func(t *testing.T) {
-		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: consoleUrl}
-		ApplyTenantRegion(creds, "")
+	t.Run("empty console url sets region only", func(t *testing.T) {
+		creds := &AwsConfigOutput{Region: "us-west-2"}
+		if !ApplyTenantRegion(creds, "us-east-2") {
+			t.Fatalf("expected true")
+		}
+		if creds.Region != "us-east-2" || creds.ConsoleUrl != "" {
+			t.Fatalf("got region=%q url=%q", creds.Region, creds.ConsoleUrl)
+		}
+	})
 
-		if creds.Region != "us-west-2" || creds.ConsoleUrl != consoleUrl {
+	t.Run("console url that cannot be rewritten reports false", func(t *testing.T) {
+		hostRegion := "https://signin.aws.amazon.com/federation?Action=login&SigninToken=abc&Destination=https%3a%2f%2fus-west-2.console.aws.amazon.com%2fconsole%2fhome"
+		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: hostRegion}
+		if ApplyTenantRegion(creds, "us-east-2") {
+			t.Fatalf("expected false")
+		}
+		if creds.Region != "us-east-2" || creds.ConsoleUrl != hostRegion {
+			t.Fatalf("got region=%q url=%q", creds.Region, creds.ConsoleUrl)
+		}
+	})
+
+	t.Run("empty region is a no-op", func(t *testing.T) {
+		creds := &AwsConfigOutput{Region: "us-west-2", ConsoleUrl: realisticConsoleUrl}
+		if ApplyTenantRegion(creds, "") {
+			t.Fatalf("expected false")
+		}
+		if creds.Region != "us-west-2" || creds.ConsoleUrl != realisticConsoleUrl {
 			t.Fatalf("expected creds unchanged, got region=%q", creds.Region)
 		}
 	})
 
 	t.Run("nil creds does not panic", func(t *testing.T) {
-		ApplyTenantRegion(nil, "us-east-2")
+		if ApplyTenantRegion(nil, "us-east-2") {
+			t.Fatalf("expected false")
+		}
 	})
 }


### PR DESCRIPTION
## Change description

`duplo-jit aws --admin` and `--duplo-ops` ignored the `--tenant` flag entirely, so the returned `Region` and the federated `ConsoleUrl` always opened in the master account's default region (e.g. `us-west-2`) rather than the selected tenant's region. This is the CLI counterpart of the UI fix delivered in DUPLO-38346.

When `--tenant` is supplied alongside `--admin`/`--duplo-ops`, the CLI now:
- resolves the tenant and looks up its region via `GetTenantFeatures`,
- overrides both the `Region` field and the `region` query param inside the console URL's `Destination` (leaving the `SigninToken` untouched),
- folds the tenant name into the cache key so admin creds are cached per-tenant instead of colliding on `host,admin`.

Behavior without `--tenant` is unchanged (master default region), as is the existing tenant-only path.

The duplicated admin/duplo-ops logic in `main.go` was factored into a shared `getAdminAwsCreds` helper.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix DUPLO-43460

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

## Testing

Verified live against `https://test24.duplocloud.net` with tenant `gds43554sec` (region `us-east-1`):

| Invocation | Region field | Console URL region |
|---|---|---|
| `--tenant gds43554sec` (baseline) | `us-east-1` | *(none embedded by backend)* |
| `--admin` (no tenant) | `us-west-2` | `us-west-2` |
| `--admin --tenant gds43554sec` | `us-east-1` | `us-east-1` |
| `--duplo-ops --tenant gds43554sec` | `us-east-1` | `us-east-1` |

The table above was run against `cf90f2c3`; the review follow-up (`85ef7a5`) only changes call ordering and adds stderr warnings on paths those invocations don't hit.

Unit tests in `internal/aws_test.go` cover `OverrideConsoleRegion` and `ApplyTenantRegion`: the encoded destination, empty/missing region, missing `Destination`, SigninToken preservation, an unparseable URL, a region encoded in the destination host (not rewritten, reported as such), and the malformed-query cases (`%zz`, `;`) that must return the input unchanged. `make test` now runs `go test ./...`, so these run in CI via `dev-test.yml`.

